### PR TITLE
Fix path not found error for os.mkdir making multi-level directory by replacing with os.makedirs

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -53,7 +53,7 @@ def download_and_uncompress_zip(URL, dataset_dir, force=False):
 
 def start_download(dataset, save_to, force):
     if not os.path.exists(save_to):
-        os.mkdir(save_to)
+        os.makedirs(save_to)
     if dataset == 'mnist':
         download_and_uncompress_zip(MNIST_TRAIN_IMGS_URL, save_to, force)
         download_and_uncompress_zip(MNIST_TRAIN_LABELS_URL, save_to, force)


### PR DESCRIPTION
Originally was failing with following error:
```
$ python download_data.py
Traceback (most recent call last):
  File "download_data.py", line 78, in <module>
    start_download(args.dataset, args.save_to, args.force)
  File "download_data.py", line 56, in start_download
    os.mkdir(save_to)
OSError: [Errno 2] No such file or directory: 'data/mnist'
```
